### PR TITLE
Bundle the app with Meteorite

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -183,7 +183,7 @@ echo "Meteor installed" | indent
 echo "Installing packages" | indent
 HOME="$BUILD_DIR" mrt install | indent
 echo "Building meteor bundle" | indent
-HOME="$VENDORED_METEOR" "$VENDORED_METEOR"/.meteor/meteor bundle "$CACHE_DIR"/bundle.tar.gz 2>&1 | indent
+HOME="$VENDORED_METEOR" mrt bundle "$CACHE_DIR"/bundle.tar.gz 2>&1 | indent
 
 mkdir -p "$METEOR_BUILD_DIR"/app
 tar -zxf "$CACHE_DIR"/bundle.tar.gz --strip-components 1 -C "$METEOR_BUILD_DIR"/app


### PR DESCRIPTION
In the current version of the buildpack, the script uses `meteor` to bundle the app. However we really should be using the `mrt` tool instead of this, doing otherwise causes the build to fail.
