### PR TITLE
Stable and updated implementation for newest Meteor versions

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -10,10 +10,6 @@ set -e
 # clean up leaking environment
 unset GIT_DIR
 
-# config
-SCONS_VERSION="1.2.0"
-S3_BUCKET="heroku-buildpack-nodejs"
-
 # parse and derive params
 BUILD_DIR=$1
 CACHE_DIR=$2
@@ -46,51 +42,11 @@ function run_npm() {
   command="$1"
 
   cd "$BUILD_DIR"
-  HOME="$BUILD_DIR" $VENDORED_NODE/bin/node $VENDORED_NPM/cli.js $command 2>&1 | indent
+  HOME="$BUILD_DIR" $VENDORED_NODE/bin/node $VENDORED_NODE/bin/npm $command 2>&1 | indent
 
   if [ "${PIPESTATUS[*]}" != "0 0" ]; then
     echo " !     Failed to $command dependencies with npm"
     exit 1
-  fi
-}
-
-function manifest_versions() {
-  curl "http://${S3_BUCKET}.s3.amazonaws.com/manifest.${1}" -s -o - | tr -s '\n' ' '
-}
-
-function resolve_version() {
-  available_versions="$1"
-  requested_version="$2"
-  default_version="$3"
-
-  args=""
-  for version in $available_versions; do args="${args} -v \"${version}\""; done
-
-  if [ "$2" == "" ]; then
-    args="${args} -r \"${default_version}\"";
-  else
-    args="${args} -r \"${requested_version}\"";
-  fi
-
-  evaluated_versions=$(eval $bootstrap_node/bin/node $LP_DIR/vendor/node-semver/bin/semver ${args} || echo "")
-  echo "$evaluated_versions" | tail -n 1
-}
-
-function package_engine_version() {
-  version=$(cat $BUILD_DIR/package.json | $bootstrap_node/bin/node $LP_DIR/vendor/json/json engines.$1 2>/dev/null)
-  if [ $? == 0 ]; then
-    echo $version | sed -e 's/\([<>=]\) /\1/g'
-  fi
-}
-
-function package_resolve_version() {
-  engine="$1"
-  resolved_version=$(resolve_version "${engine_versions[$engine]}" "${engine_requests[$engine]}" "${engine_defaults[$engine]}")
-
-  if [ "${resolved_version}" == "" ]; then
-    error "Requested engine $engine version ${engine_requests[$engine]} does not match available versions: ${engine_versions[$engine]}"
-  else
-    echo $resolved_version
   fi
 }
 
@@ -100,85 +56,45 @@ function package_download() {
   location="$3"
 
   mkdir -p $location
-  package="http://${S3_BUCKET}.s3.amazonaws.com/$engine-$version.tgz"
-  curl $package -s -o - | tar xzf - -C $location
+  package="http://s3pository.heroku.com/$engine/v$version/$engine-v$version-linux-x64.tar.gz"
+  echo " - downloading and extracting $engine from $package" | indent
+  curl $package -s -o - | tar -zxf  - -C $location --strip 1
 }
-
-function cat_npm_debug_log() {
-  if [ -f $BUILD_DIR/npm-debug.log ]; then
-    cat $BUILD_DIR/npm-debug.log
-  fi
-}
-
-trap cat_npm_debug_log EXIT
-
-bootstrap_node=$(mktmpdir bootstrap_node)
-package_download "nodejs" "0.4.7" $bootstrap_node
-
-# make some associative arrays
-declare -A engine_versions
-declare -A engine_defaults
-declare -A engine_requests
-
-engine_defaults["node"]="0.10.x"
-engine_defaults["npm"]="1.3.x"
-
-engine_versions["node"]=$(manifest_versions "nodejs")
-engine_requests["node"]=$(package_engine_version "node")
-
-engine_versions["npm"]=$(manifest_versions "npm")
-engine_requests["npm"]=$(package_engine_version "npm")
 
 echo "-----> Resolving engine versions"
 
+#TODO: Fix package.json loading
+#if [ -f "${BUILD_DIR}/package.json" ]; then
+#  requested_node_ver=$(cat $BUILD_DIR/package.json | $LP_DIR/vendor/jq -r .engines.node)
+#fi
+requested_node_ver=""
 # add a warning if no version of node specified
-if [ "${engine_requests["node"]}" == "" ]; then
+if [ "${requested_node_ver}" == "" ]; then
+  requested_node_ver="stable"
   echo
-  echo "WARNING: No version of Node.js specified in package.json, see:" | indent
+  echo "No version of Node.js specified in package.json, using latest stable, see:" | indent
   echo "https://devcenter.heroku.com/articles/nodejs-versions" | indent
   echo
 fi
 
-NODE_VERSION=$(package_resolve_version "node")
+NODE_VERSION=$(curl --silent --get --data-urlencode "range=${requested_node_ver}" https://semver.io/node/resolve)
 echo "Using Node.js version: ${NODE_VERSION}" | indent
-
-NPM_VERSION=$(package_resolve_version "npm")
-echo "Using npm version: ${NPM_VERSION}" | indent
-
-# cache directories
-CACHE_STORE_DIR="$CACHE_DIR/node_modules/$NODE_VERSION"
-CACHE_TARGET_DIR="$BUILD_DIR/node_modules"
-
-# s3 packages
-NODE_PACKAGE="http://${S3_BUCKET}.s3.amazonaws.com/nodejs-${NODE_VERSION}.tgz"
-NPM_PACKAGE="http://${S3_BUCKET}.s3.amazonaws.com/npm-${NPM_VERSION}.tgz"
-SCONS_PACKAGE="http://${S3_BUCKET}.s3.amazonaws.com/scons-${SCONS_VERSION}.tgz"
 
 # vendor directories
 VENDORED_NODE="$(mktmpdir node)"
-VENDORED_NPM="$(mktmpdir npm)"
-VENDORED_SCONS="$(mktmpdir scons)"
 VENDORED_MODULES="$(mktmpdir modules)"
 
 # download and unpack packages
 echo "-----> Fetching Node.js binaries"
-package_download "nodejs" "${NODE_VERSION}" "${VENDORED_NODE}"
-package_download "npm" "${NPM_VERSION}" "${VENDORED_NPM}"
-package_download "scons" "${SCONS_VERSION}" "${VENDORED_SCONS}"
+package_download "node" "${NODE_VERSION}" "${VENDORED_NODE}"
 
 # setting up paths for building
-PATH="$VENDORED_SCONS:$VENDORED_NODE/bin:$VENDORED_MODULES/bin:$PATH"
+PATH="$VENDORED_NODE/bin:$VENDORED_MODULES/bin:$PATH"
 INCLUDE_PATH="$VENDORED_NODE/include"
 export npm_config_prefix="$VENDORED_MODULES"
-export CPATH="$INCLUDE_PATH:$CPATH"
-export CPPPATH="$INCLUDE_PATH:$CPPPATH"
+export CPATH="$INCLUDE_PATH"
+export CPPPATH="$INCLUDE_PATH"
 
-## TODO -- figure out which node dependencies need to be installed
-# # install dependencies with npm
-# echo "-----> Installing dependencies with npm"
-# run_npm "install --production"
-# run_npm "rebuild"
-# echo "Dependencies installed" | indent
 
 ############################################
 # install meteorite


### PR DESCRIPTION
This fixes all of the problems with outdated node versions and is tested to work out of the box with a stock Meteorite project.

Furthermore it now fetches the latest Node.JS stable version from https://semver.io/node/resolve?range=stable

You can define somewhat semantic values for the range, like https://semver.io/node/resolve?range=0.11.x

It fetches this value and downloads from the new Heroku repository proxy, which is much faster than using the direct amazon S3 url.

This update follows the pattern of the latest Heroku Node.JS buildpack.
